### PR TITLE
doc: Add f-port flag to example command in downlink-queue-ops

### DIFF
--- a/doc/content/devices/downlink-queue-ops/_index.md
+++ b/doc/content/devices/downlink-queue-ops/_index.md
@@ -34,6 +34,7 @@ To replace the existing queue with a new item:
 $ ttn-lw-cli end-devices downlink replace app1 dev1 \
   --frm-payload 01020304 \
   --priority NORMAL
+  --f-port 42
 ```
 
 ## List queue


### PR DESCRIPTION
#### Summary
`--f-port` flag is missing in the example CLI command to replace the existing downlink queue with a new item.

#### Changes
Added `--f-port` flag in the example command.

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.