### PR TITLE
doc: Corrected the link on device claiming

### DIFF
--- a/doc/content/devices/device-claiming/_index.md
+++ b/doc/content/devices/device-claiming/_index.md
@@ -2,7 +2,7 @@
 title: "Device Claiming"
 description: ""
 distributions: ["Enterprise", "Cloud"]
---- 
+---
 
 Device claiming is a mechanism that transfers devices securely from one application to another. This section provides guides for making devices claimable and claiming them.
 
@@ -19,8 +19,8 @@ It is used to transfer ownership from a device maker to a device owner, or to a 
 
 ## How does it work?
 
-After pre-provisioning a device, device makers register it on The Things Industries Join Server or on their Cloud cluster, generate a QR code for claiming and stick it to the device. When purchasing a device, new device owners scan this QR code to claim it to their application. 
+After pre-provisioning a device, device makers register it on The Things Industries Join Server or on their Cloud cluster, generate a QR code for claiming and stick it to the device. When purchasing a device, new device owners scan this QR code to claim it to their application.
 
-[Learn how to claim a device]({{< ref "/devices/device-claiming" >}})
+[Learn how to claim a device]({{< ref "/devices/device-claiming/claim-devices" >}})
 
 {{< note >}} Device claiming does not transfer a security session for a device, it only transfers ownership. The original LoRaWAN session is deleted. The device needs to join the network again for traffic to appear. {{</ note >}}


### PR DESCRIPTION
#### Summary
- Incorrect link was provided for navigation to **learn how to claim a device** in Device Claiming Overview section.
Ref: https://www.thethingsindustries.com/docs/devices/device-claiming/

#### Changes
- Corrected the link for **learn how to claim a device**.

#### Checklist 
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
