### PR TITLE
doc: Corrected the link on device claiming

### DIFF
--- a/doc/content/devices/device-claiming/_index.md
+++ b/doc/content/devices/device-claiming/_index.md
@@ -21,6 +21,6 @@ It is used to transfer ownership from a device maker to a device owner, or to a 
 
 After pre-provisioning a device, device makers register it on The Things Join Server or on their Cloud cluster, generate a QR code for claiming and stick it to the device. When purchasing a device, new device owners scan this QR code to claim it to their application. 
 
-[Learn how to claim a device]({{< ref "/devices/device-claiming/claim-devices/" >}})
+[Learn how to claim a device]({{< ref "/devices/device-claiming/claim-devices" >}})
 
 {{< note >}} Device claiming does not transfer a security session for a device, it only transfers ownership. The original LoRaWAN session is deleted. The device needs to join the network again for traffic to appear. {{</ note >}}


### PR DESCRIPTION

#### Summary
Corrected the link on how to claim a device in the Device Claiming section.
Ref: https://www.thethingsindustries.com/docs/devices/device-claiming/

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
