### PR TITLE
doc: Add command to disable the storage integration for a device

### DIFF
--- a/doc/content/integrations/storage/enable.md
+++ b/doc/content/integrations/storage/enable.md
@@ -33,9 +33,9 @@ $ ttn-lw-cli applications packages associations set "app1" "dev1" 100 --package-
 
 {{< warning >}} **Do not configure multiple associations for the same end device**, since that will lead to storing duplicate uplinks in the persistent storage. {{</ warning >}}
 
-## Disable the Storage Integration
+## Disable for an Application
 
-Delete the package association, or the default association:
+Delete the default association:
 
 ```bash
 # List default associations
@@ -60,3 +60,38 @@ $ ttn-lw-cli applications packages default-associations list "app1"
 ```bash
 $ ttn-lw-cli applications packages default-associations delete "app1" 100
 ```
+
+## Disable for an End Device
+
+Delete the package association:
+
+```bash
+# List package associations
+$ ttn-lw-cli applications packages associations list "app1" "dev1"
+{
+  "associations": [
+    {
+      "ids": {
+        "end_device_ids": {
+          "device_id": "dev1",
+          "application_ids": {
+            "application_id": "app1"
+          }
+        },
+        "f_port": 100
+      },
+      "created_at": "2020-08-24T21:09:44.649890166Z",
+      "updated_at": "2020-08-24T21:09:44.649890166Z",
+      "package_name": "storage-integration"
+    }
+  ]
+}
+
+
+```
+
+```bash
+$ ttn-lw-cli applications packages associations delete "app1" "dev1" 100
+```
+
+


### PR DESCRIPTION
#### Summary
Added the CLI command to disable the storage integration for a single end-device.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.