### PR TITLE
doc: Add command to disable storage intgration for device

### DIFF
--- a/doc/content/integrations/storage/disable.md
+++ b/doc/content/integrations/storage/disable.md
@@ -1,0 +1,71 @@
+---
+title: Disable
+description: ""
+summary: Disable Storage Integration for applications and end-devices.
+weight: 30
+---
+
+The Storage Integration is implemented as an [Application Package]({{< ref "/reference/application-packages" >}}). In order to disable it, you have to delete a default association for an application and a package association for an end-device.
+
+{{< cli-only >}}
+
+## Disable for an Application
+
+Delete the default association:
+
+```bash
+# List default associations
+$ ttn-lw-cli applications packages default-associations list "app1"
+{
+  "defaults": [
+    {
+      "ids": {
+        "application_ids": {
+          "application_id": "app1"
+        },
+        "f_port": 100
+      },
+      "created_at": "2020-08-24T21:09:44.649890166Z",
+      "updated_at": "2020-08-24T21:09:44.649890166Z",
+      "package_name": "storage-integration"
+    }
+  ]
+}
+```
+
+```bash
+$ ttn-lw-cli applications packages default-associations delete "app1" 100
+```
+
+## Disable for an End Device
+
+Delete the package association:
+
+```bash
+# List package associations
+$ ttn-lw-cli applications packages associations list "app1" "dev1"
+{
+  "associations": [
+    {
+      "ids": {
+        "end_device_ids": {
+          "device_id": "dev1",
+          "application_ids": {
+            "application_id": "app1"
+          }
+        },
+        "f_port": 100
+      },
+      "created_at": "2020-08-24T21:09:44.649890166Z",
+      "updated_at": "2020-08-24T21:09:44.649890166Z",
+      "package_name": "storage-integration"
+    }
+  ]
+}
+
+
+```
+
+```bash
+$ ttn-lw-cli applications packages associations delete "app1" "dev1" 100
+```

--- a/doc/content/integrations/storage/enable.md
+++ b/doc/content/integrations/storage/enable.md
@@ -32,31 +32,3 @@ $ ttn-lw-cli applications packages associations set "app1" "dev1" 100 --package-
 {{< note >}} The `f_port` value is irrelevant. {{</ note >}}
 
 {{< warning >}} **Do not configure multiple associations for the same end device**, since that will lead to storing duplicate uplinks in the persistent storage. {{</ warning >}}
-
-## Disable the Storage Integration
-
-Delete the package association, or the default association:
-
-```bash
-# List default associations
-$ ttn-lw-cli applications packages default-associations list "app1"
-{
-  "defaults": [
-    {
-      "ids": {
-        "application_ids": {
-          "application_id": "app1"
-        },
-        "f_port": 100
-      },
-      "created_at": "2020-08-24T21:09:44.649890166Z",
-      "updated_at": "2020-08-24T21:09:44.649890166Z",
-      "package_name": "storage-integration"
-    }
-  ]
-}
-```
-
-```bash
-$ ttn-lw-cli applications packages default-associations delete "app1" 100
-```

--- a/doc/content/integrations/storage/retrieve.md
+++ b/doc/content/integrations/storage/retrieve.md
@@ -1,7 +1,7 @@
 ---
 title: Retrieve messages
 summary: Retrieve historical data using the HTTP API
-weight: 30
+weight: 40
 ---
 
 The Storage Integration offers the `ApplicationUpStorage` gRPC service and the respective HTTP endpoints for retrieving historical data. This page merely contains a few examples, see [Reference]({{< ref "/reference/api/storage_integration" >}}) for more details.


### PR DESCRIPTION
#### Summary
Added the CLI command to disable the storage integration for a single end-device and re-ordered pages.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.