### PR TITLE
doc: Add regex pattern allowed for deviceID

### DIFF
--- a/doc/content/integrations/aws-iot/default/things.md
+++ b/doc/content/integrations/aws-iot/default/things.md
@@ -70,7 +70,7 @@ When creating things, you need to specify the minimum attributes for creating Lo
 - `regionalParametersVersion`: either `1.0`, `1.0.1`, `1.0.2` (or `1.0.2-a`), `1.0.2-b`, `1.0.3-a`, `1.1-a` or `1.1-b`
 - `appKey`: hexadecimal LoRaWAN AppKey
 - `nwkKey`: hexadecimal LoRaWAN NwkKey (only when using LoRaWAN 1.1 or higher)
-- Optional `deviceID`: the device ID that will be used to create the device in your {{% tts %}} application. When omitted, the integration uses `eui-<dev-eui>` as device ID.
+- Optional `deviceID`: the device ID that will be used to create the device in your {{% tts %}} application. The deviceID should follow the pattern `^[a-z0-9](?:[-]?[a-z0-9]){2,}$`. When omitted, the integration uses `eui-<dev-eui>` as device ID.
 - Optional `frequencyPlanID`: the frequency plan ID. See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) for the supported values. When omitted, the default frequency plan of your AWS region is used. See the **Outputs** section of your AWS CloudFormation stack to see which one that is.
 
 {{< figure src="../create-thing-3.png" alt="Create Thing" >}}


### PR DESCRIPTION
#### Summary

Added the regular expression pattern `^[a-z0-9](?:[-]?[a-z0-9]){2,}$` allowed for Device ID in TTS


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.