### PR TITLE
doc: Modify CLI installation guide for Linux, macOS & Windows

### DIFF
--- a/doc/content/getting-started/cli/installing-cli/_index.md
+++ b/doc/content/getting-started/cli/installing-cli/_index.md
@@ -7,6 +7,38 @@ weight: 1
 This section contains instructions for installing the command-line interface.
 
 <!--more-->
+{{< tabs/container "Linux" "macOS" "Windows" >}}
+
+<!-- _______________________________________________________________Linux________________________________________________________________________ -->
+{{< tabs/tab "Linux" >}}
+
+
+<!--more-->
+
+### Package managers (recommended)
+
+#### Linux
+
+Open the `terminal` in Linux and run the below commands to install the package manager.
+
+```bash
+$ sudo snap install ttn-lw-stack
+$ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
+```
+
+[Adding image of the package manager installation in progress]
+
+{{< note >}} When installing with `snap`, auto-completion is enabled automatically. {{</ note >}}
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________macOS________________________________________________________________________ -->
+
+{{< tabs/tab "macOS" >}}
+
+<!--more-->
 
 ### Package managers (recommended)
 
@@ -18,38 +50,66 @@ $ brew install TheThingsNetwork/lorawan-stack/ttn-lw-stack
 
 {{< note >}} When installing with `brew`, auto-completion is enabled automatically. {{</ note >}}
 
-#### Linux
 
-```bash
-$ sudo snap install ttn-lw-stack
-$ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
-```
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
 
-{{< note >}} When installing with `snap`, auto-completion is enabled automatically. {{</ note >}}
 
-### Binaries
+<!-- ____________________________________________________________Windows________________________________________________________________________ -->
+
+{{< tabs/tab "Windows" >}}
+
+### Package managers (recommended)
 
 You can download [pre-built binaries](https://github.com/TheThingsNetwork/lorawan-stack/releases) for your operating system and processor architecture.
 
-## Configuration
+{{< note >}} Make sure to download the latest binaries with every new release of the stack. To know your windows system architecture, run the below command in the windows command prompt `$ echo %PROCESSOR_ARCHITECTURE%` {{</ note >}}
 
-The command-line needs to be configured to connect to your deployment on `thethings.example.com`. You have multiple options to make the configuration file available to the CLI:
+Extract the downloaded `.zip` file and in the extracted folder you can find `ttn-lw-cli.exe` file.
 
-1. Environment: `export TTN_LW_CONFIG=/path/to/ttn-lw-cli.yml`
-2. Command-line flag: `-c /path/to/ttn-lw-cli.yml`
-3. Save as `.ttn-lw-cli.yml` in `$XDG_CONFIG_HOME`, your home directory, or the working directory.
 
-{{< warning >}} When using the snap packages, `~/.ttn-lw-cli.yml` will fail with permission errors. Choose a different path. {{</ warning >}}
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
 
-### Generate configuration file
+## Generate configuration file
 
 For a standard deployment on `thethings.example.com`, all you need is:
+
+<!-- _______________________________________________________________Linux________________________________________________________________________ -->
+
+{{< tabs/tab "Linux" >}}
+
 
 ```bash
 $ ttn-lw-cli use thethings.example.com [--fetch-ca] [--user] [--overwrite]
 ```
 
-{{< note >}} On Windows, use `ttn-lw-cli.exe` instead of `ttn-lw-cli`. {{</ note >}}
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________macOS________________________________________________________________________ -->
+
+{{< tabs/tab "macOS" >}}
+
+```bash
+$ ttn-lw-cli use thethings.example.com [--fetch-ca] [--user] [--overwrite]
+```
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________Windows________________________________________________________________________ -->
+
+{{< tabs/tab "Windows" >}}
+
+```bash
+$ ttn-lw-cli.exe use thethings.example.com [--fetch-ca] [--user] [--overwrite]
+```
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
 
 This will generate and save the required CLI config file. By default, the file is saved on the current directory, use the `--user` to save it under the user config directory.
 
@@ -59,9 +119,54 @@ If the deployment is using a CA that is not already trusted by your system, use 
 
 {{< note >}} You can also use the `--grpc-port` and `--oauth-server-address` flags to override the default values for the gRPC port and the OAuth server address. These are not needed for standard deployments. {{</ note >}}
 
-### Manually creating configuration file
+{{< note >}} For the Cloud-Hosted Deployments in clusters other than `eu1`, please follow the steps in the below section. {{</ note >}}
+
+
+<!-- _______________________________________________________________Linux________________________________________________________________________ -->
+
+{{< tabs/tab "Linux" >}}
+
+Create a file named `.ttn-lw-cli.yml` by running the below command in `terminal`.
+
+```bash
+$ touch .ttn-lw-cli.yml
+```
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________macOS________________________________________________________________________ -->
+
+{{< tabs/tab "macOS" >}}
+
+Create a file named `.ttn-lw-cli.yml` by running the below command in `terminal`.
+
+```bash
+$ touch .ttn-lw-cli.yml
+```
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________Windows________________________________________________________________________ -->
+
+{{< tabs/tab "Windows" >}}
+
+Navigate to the working directory and create a file named `.ttn-lw-cli.yml` in the extracted folder by executing the below command.
+
+```bash
+$ type nul > .ttn-lw-cli.yml
+``` 
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
 
 Alternatively, you can create a file named `.ttn-lw-cli.yml` and paste the following contents:
+
+{{< note >}} For the Cloud-Hosted Deployments, navigate to the [Cloud Addresses](https://enterprise.thethingsstack.io/getting-started/cloud-hosted/addresses/) and enter the `tenant-id` and choose the `cluster` for which you want to generate the content of the CLI configuration file. After filling in those details, copy the contents in the `Command-line Interface` section on the same page and paste them into the `.ttn-lw-cli.yml` file created earlier. {{</ note >}}
 
 ```yaml
 oauth-server-address: 'https://thethings.example.com/oauth'
@@ -90,6 +195,22 @@ ca: /path/to/ca.pem
 
 For advanced options, see the [Configuration Reference]({{< ref "/reference/configuration/cli" >}}).
 
+
+
+<!-- _______________________________________________________________Linux________________________________________________________________________ -->
+
+{{< tabs/tab "Linux" >}}
+
+## Configuration
+
+The command-line needs to be configured to connect to your deployment on `thethings.example.com`. You have multiple options to make the configuration file available to the CLI:
+
+1. Environment: `export TTN_LW_CONFIG=/path/to/.ttn-lw-cli.yml`
+2. Command-line flag: `-c /path/to/.ttn-lw-cli.yml`
+3. Save as `.ttn-lw-cli.yml` in `$XDG_CONFIG_HOME`, your home directory, or the working directory.
+
+{{< warning >}} When using the snap packages, `~/.ttn-lw-cli.yml` will fail with permission errors. Choose a different path. {{</ warning >}}
+
 ## Auto Completion
 
 Use `ttn-lw-cli complete` to generate an auto-completion script for the `ttn-lw-cli` command. `bash`, `zsh`, `fish` and `powershell` shells are supported:
@@ -112,10 +233,86 @@ For `bash`, this directory is typically `/etc/bash_completion.d/`:
 $ sudo cp ./ttn-lw-cli-autocomplete /etc/bash_completion.d/
 ```
 
-Generating and sourcing an auto-completion PowerShell script on Windows is slightly modified:
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________macOS________________________________________________________________________ -->
+
+{{< tabs/tab "macOS" >}}
+
+## Configuration
+
+The command-line needs to be configured to connect to your deployment on `thethings.example.com`. You have multiple options to make the configuration file available to the CLI:
+
+1. Environment: `export TTN_LW_CONFIG=/path/to/.ttn-lw-cli.yml`
+2. Command-line flag: `-c /path/to/.ttn-lw-cli.yml`
+3. Save as `.ttn-lw-cli.yml` in `$XDG_CONFIG_HOME`, your home directory, or the working directory.
+
+{{< warning >}} When using the snap packages, `~/.ttn-lw-cli.yml` will fail with permission errors. Choose a different path. {{</ warning >}}
+
+## Auto Completion
+
+Use `ttn-lw-cli complete` to generate an auto-completion script for the `ttn-lw-cli` command. `bash`, `zsh`, `fish` and `powershell` shells are supported:
+
+```bash
+$ ttn-lw-cli complete --shell bash --executable ttn-lw-cli > ttn-lw-cli-autocomplete
+```
+
+Source the file to enable auto-completion:
+
+```bash
+$ . ./ttn-lw-cli-autocomplete
+```
+
+Alternatively, put in a default directory so that it is loaded automatically (This directory depends on your Operating System and your shell).
+
+For `bash`, this directory is typically `/etc/bash_completion.d/`:
+
+```bash
+$ sudo cp ./ttn-lw-cli-autocomplete /etc/bash_completion.d/
+```
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+
+<!-- ____________________________________________________________Windows________________________________________________________________________ -->
+
+{{< tabs/tab "Windows" >}}
+
+## Configuration
+
+The command-line needs to be configured to connect to your deployment on `thethings.example.com`. Run the below command to make the configuration file available to the CLI:
+
+Environment: `set TTN_LW_CONFIG=/path/to/.ttn-lw-cli.yml`
+
+## Auto Completion
+
+Use `ttn-lw-cli complete` to generate an auto-completion script for the `ttn-lw-cli` command. `bash`, `zsh`, `fish` and `powershell` shells are supported:
 
 ```bash
 $ ttn-lw-cli.exe complete --shell powershell --executable ttn-lw-cli.exe > ttn-lw-cli-autocomplete.ps1
+```
 
+Source the file to enable auto-completion:
+
+```bash
 $ . ./ttn-lw-cli-autocomplete.ps1
 ```
+
+Alternatively, put in a default directory so that it is loaded automatically (This directory depends on your Operating System and your shell).
+
+
+{{< /tabs/tab >}}
+<!-- ____________________________________________________________END________________________________________________________________________ -->
+
+---
+
+{{< note >}} For Cloud-Hosted Deployments, the oauth-server-address and identity-server-grpc-address will be in the `eu1` cluster even if you select the `nam1`/`au1` clusters. Also, the command-line needs to be configured to connect to your deployment on `<tenant-id>.eu1.cloud.thethings.industries`. For configuration run the below command in the terminal. Setting Environment - Set the CLI path to `ttn-lw-cli` directory and execute
+
+
+```bash
+$ export TTN_LW_CONFIG=~/path/to/.ttn-lw-cli.yml 
+```
+{{</ note >}}


### PR DESCRIPTION
#### Summary
Improvized the CLI installation guide with instructions for the three platforms Linux, macOS & Windows.

#### Changes
- Changed the documentation structure with separate tabs containing installation steps to be performed in Linux, Windows, and macOS.
- Added steps to install CLI in windows.
- Re-organized the `Configuration` & `Generate configuration file` sections.
  - Reason for this is we will generate a configuration file first and then configure the CLI
- Added note to get the cloud-hosted address for CLI configuration.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
