### PR TITLE
doc: Added note to change RX1 Delay in configure-mac-settings

### DIFF
--- a/doc/content/getting-started/migrating/configure-mac-settings.md
+++ b/doc/content/getting-started/migrating/configure-mac-settings.md
@@ -6,4 +6,6 @@ aliases: "/getting-started/migrating-from-v2/configure-mac-settings"
 
 MAC settings on {{% tts %}} are configurable per end device - see the [MAC settings guide]({{< ref "reference/api/end_device#message:MACSettings" >}}) for instructions.
 
-{{< warning >}} The RX1 delay of end devices is set to 1 second by default. For some end devices, this may lead to downlink messages not being scheduled in time. Therefore, it is recommended that the RX1 delay be increased to 5 seconds. {{</ warning >}}
+{{< warning >}} The RX1 delay of end devices is set to 1 second by default. For some end devices, this may lead to downlink messages not being scheduled in time. Therefore, it is recommended that the RX1 delay be increased to 5 seconds. {{</ warning >}} 
+
+{{< note >}} If you are migrating a session from a Network Server having a different value for RX1 Delay, then `mac-state.current-parameters.rx1-delay` should be set to that value as well. {{</ note >}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
The Rx1Delay in the example JSON file provided in the migrate with the session section is RX_DELAY_5, whereas it might be same for all the source Network Servers.

#### Changes
<!-- What are the changes made in this pull request? -->
- Added a note to change the `mac-state.current-parameters.rx1-delay` after migrating a device from an NS having different RX1 Delay setting

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
