### PR TITLE
doc: Update aws integration end-to-end-encryption section

### DIFF
--- a/doc/content/integrations/aws-iot/default/architecture.md
+++ b/doc/content/integrations/aws-iot/default/architecture.md
@@ -24,6 +24,8 @@ This is a serverless deployment: there are no compute resources being deployed. 
 
 This integration supports true LoRaWAN end-to-end encryption: the application payload is encrypted on the end device with the LoRaWAN AppSKey, and decrypted in your AWS Account. The underlying network infrastructure passes your application payload in the encrypted form - it cannot see your data.
 
-When enabled, this integration configures The Things Join Server with your key encryption key (KEK) that is generated in your AWS Account and stored as a secret in [Secrets Manager](https://aws.amazon.com/secrets-manager/). The Things Join Server encrypts the AppSKey with the KEK before passing it to the network layer. The network layer sends the encrypted AppSKey to your AWS Account, where it gets decrypted. This feature only works with devices registered in The Things Join Server.
+When enabled, this integration configures Join Server with your key encryption key (KEK) that is generated in your AWS Account and stored as a secret in [Secrets Manager](https://aws.amazon.com/secrets-manager/). Join Server encrypts the AppSKey with the KEK before passing it to the network layer. The network layer sends the encrypted AppSKey to your AWS Account, where it gets decrypted. This feature only works with devices registered in Join Server.
 
 When using this feature, your AWS application needs to process the LoRaWAN application payload in binary form, as the network layer's payload encoding and decoding functions cannot work with the encrypted data.
+
+This feature works with devices registered using both The Things Join Server or in-cluster Join server of The Things Stack Cloud.

--- a/doc/content/integrations/aws-iot/default/deployment-guide.md
+++ b/doc/content/integrations/aws-iot/default/deployment-guide.md
@@ -50,7 +50,7 @@ The parameters configure the integration:
 - **Thing Type Name**: The unique AWS IoT Core thing type name for this integration.
 - **Thing Shadow Metrics**: Enable or disable updating the thing shadow with metrics.
 - **Cluster Address**: The cluster address of your {{% tts %}} deployment, for example `mycompany.eu1.cloud.thethings.industries`. See [Cloud Hosted Addresses]({{< relref "/getting-started/cloud-hosted/addresses" >}}) to find your cluster address.
-- **Enable End-to-End Encryption** {{< new-in-version "3.10.0" >}} {{< distributions-inline "Cloud" >}}: If enabled, the AppSKey is delivered as encrypted from The Things Join Server to your AWS Account, so the AppSKey will not be exposed to the network layer. Also, your AWS solution needs to handle binary payload as the underlying network cannot run payload encoding and decoding functions.
+- **Enable End-to-End Encryption** {{< new-in-version "3.10.0" >}} {{< distributions-inline "Cloud" >}}: If enabled, the AppSKey is delivered as encrypted from Join Server to your AWS Account, so the AppSKey will not be exposed to the network layer. Also, your AWS solution needs to handle binary payload as the underlying network cannot run payload encoding and decoding functions.
 - **Application ID**: The application ID for which you configure the integration.
 - **Application API Key**: The application API key that you generated before.
 


### PR DESCRIPTION
#### Summary
Updated the AWS IoT integration end-to-end-encryption section

#### Changes

Updated `The Things Join Server` to `Join server` and added sentence related to the end-to-end-encryption will work for devices that are registered in `The Things Join Server` or `In-cluster Join Server`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
