### PR TITLE
doc: Add cli configuration yml file for The Things Stack Public Network

### DIFF
--- a/doc/content/getting-started/cli/installing-cli/_index.md
+++ b/doc/content/getting-started/cli/installing-cli/_index.md
@@ -61,6 +61,14 @@ For a standard deployment on `thethings.example.com`, all you need is:
 $ ttn-lw-cli use thethings.example.com [--fetch-ca] [--user] [--overwrite]
 ```
 
+
+For The Things Stack Public network, all you need is:
+
+
+```bash
+$ ttn-lw-cli use eu1.cloud.thethings.network [--overwrite]
+```
+
 {{< note >}} On Windows, use `ttn-lw-cli.exe` instead of `ttn-lw-cli`. {{</ note >}}
 
 This will generate and save the required CLI config file. By default, the file is saved on the current directory, use the `--user` to save it under the user config directory.
@@ -87,6 +95,11 @@ device-claiming-server-grpc-address: 'thethings.example.com:8884'
 device-template-converter-grpc-address: 'thethings.example.com:8884'
 qr-code-generator-grpc-address: 'thethings.example.com:8884'
 ```
+
+If you are using The Things Stack public network, all you have to replace
+
+`thethings.example.com` with `eu1.cloud.thethings.network`
+
 
 If you are using an `https` port other than `443`, you need to specify that port, e.g.:
 


### PR DESCRIPTION
#### Summary

Added the Things Things Stack Public Network Command line configuration yml file generation


#### Screenshots

#### Changes
- Added The Things Stack Public Network cli configuration file generation command
- Added how to use the existing cli configurations to The Things Stack Public Network

#### Notes for Reviewers
This will helpful for configuring the cli, those who are using The Things Stack Public Network.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
