### PR TITLE
doc: Update migrations doc

### DIFF
--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -25,7 +25,7 @@ When migrating devices from the public {{< ttnv2 >}} to {{< tts >}} Cloud, you m
 
 When migrating from a private {{% ttnv2 %}}, devices that are outside of the DevAddr address block supported by {{% tts %}} Cloud will have to rejoin the network, otherwise {{% tts %}} will be unable to route their uplink and downlink traffic.
 
-{{< warning >}} Migrating device sessions will not work on {{% tts %}} v3.10 or older versions. {{</ warning >}}
+{{< warning >}} Migrating device sessions is currently not possible, and is in the pipeline. It will be available in future releases.{{</ warning >}}
 
 ## Pre-requisites
 


### PR DESCRIPTION

#### Summary
In the current documentation, it states that migrations with the session were not possible on v3.10 or older versions. Customers are getting confused by this sentence.

#### Changes
Updated the migrations with session sentence in the migrations doc

#### Checklist


- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
