### PR TITLE
doc: Change federated-auth oidc provider registration command

### DIFF
--- a/doc/content/reference/federated-auth/oidc.md
+++ b/doc/content/reference/federated-auth/oidc.md
@@ -24,7 +24,7 @@ Where `my-oidc-provider` is the ID that you have chosen for this OpenID Connect 
 After you have created the OAuth2 client you may register the provider using the `is-db` stack command:
 
 ```bash
-$ ttn-lw-stack is-db create-auth-provider
+$ tti-lw-stack is-db create-auth-provider
     --id my-oidc-provider
     --name "My OIDC Provider"
     --allow-registrations true


### PR DESCRIPTION
#### Summary
Rectified the federated [authentication provider registration ](https://www.thethingsindustries.com/docs/reference/federated-auth/oidc/#how-can-i-register-an-openid-connect-provider-)command to register in  identity server 
Ref: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/344

#### Changes
`ttn-lw-cli` to `tti-lw-cli`

#### Notes for Reviewers


#### Checklist

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
