### PR TITLE
doc: Add note to migrating from v2 page about dev_id constraints in v3

### DIFF
--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -116,4 +116,8 @@ $ ttn-lw-migrate application --verbose --dry-run --source ttnv2 "my-ttn-app" > a
 $ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
 ```
 
+{{< note >}} In TTS V3, underscores ( _ ) are not allowed in the end device ID. Using the `ttn-lw-migrate` tool will replace an underscore ( _ ) with a dash ( - ). {{</ note >}}
+
 After exporting the end devices in to a json file you can refer to [Import End Devices Document]({{< ref "getting-started/migrating/import-devices.md" >}}) in {{% tts %}} for next steps.
+
+


### PR DESCRIPTION

#### Summary

In v2 the device id accepts `_` but in v3 it won't accept any more. The related note is added.

#### Screenshots

...

#### Changes
- Added note related to device id constraint while  migrating from v2 to v3

#### Notes for Reviewers

...

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
