### PR TITLE
doc: Add note for Class C device

### DIFF
--- a/doc/content/devices/class-c/_index.md
+++ b/doc/content/devices/class-c/_index.md
@@ -23,7 +23,10 @@ This will enable the Class C downlink scheduling of the device. That's it! Downl
 
 To disable Class C scheduling, reset with `--supports-class-c=false`.
 
-{{< note >}} For unicast devices, Class C downlink scheduling starts after the end device sends an uplink in the session. This means that an OTAA end device should send an uplink message after receiving the join-accept in order to enable Class C downlink scheduling. {{</ note >}}
+{{< note >}} 
+1. For unicast devices, Class C downlink scheduling starts after the end device sends an uplink in the session. This means that an OTAA end device should send an uplink message after receiving the join-accept in order to enable Class C downlink scheduling. 
+2. For an active device, if you enable the supports-class-c option, the setting will take effect after OTAA join or ABP FCnt reset, ResetInd, or after MAC state reset. So, please ensure to re-join a device after you have enabled the supports-class-c option.
+{{</ note >}}
 
 ## Multicast Group
 


### PR DESCRIPTION
#### Summary
When the support class c option is enabled for an active device, the changes will take effect after the device re-join the network (OTAA) or on device reset (ABP). Added a note to make it clear to the users on this behavior. 

#### Screenshots
...

#### Changes
Added the below point as a note.
> For an active device, if you enable the supports-class-c option, the setting will take effect after OTAA join or ABP FCnt reset, ResetInd, or after MAC state reset. So, please ensure to re-join a device after you have enabled the supports-class-c option.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
