### PR TITLE
Add prerequisites section for MTCDT to support LBS

### DIFF
--- a/doc/content/gateways/multitechconduit/lbs.md
+++ b/doc/content/gateways/multitechconduit/lbs.md
@@ -7,6 +7,12 @@ This section contains instructions for connecting the Multitech Conduit AEP to {
 
 <!--more-->
 
+## Prerequisites:
+1. Multitech Conduit AEP gateway running [mPower 5.3.0 firmware or later](http://www.multitech.net/developer/downloads/).
+1. Hardware required: MTCDT with `MTAC-LORA-H mCard`
+
+{{< warning >}}{{% lbs %}} does not support on Multitech Conduit gateways with `MTAC-LORA-1.0` USB cards. {{</ warning >}}
+
 To set up LoRa packet forwarding on the gateway, follow these steps.
 
 Click the **LoRaWAN** tab in the left menu.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Updating the prerequisites section to the current documentation of the `Multitech Conduit AEP` gateway connecting with the LoRa Basics Station(LBS) to TTS. 
Ref: https://www.thethingsindustries.com/docs/gateways/multitechconduit/

#### Changes
<!-- What are the changes made in this pull request? -->
- Added the `prerequisites` section in the current documentation

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
